### PR TITLE
Add Cache to Mob Generator

### DIFF
--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -83,21 +83,21 @@ public class GeneratorMob extends AbstractEnergyProvider {
     try {
       BlockPosition p = new BlockPosition(l);
       UUID uuid = cachedEntity.get(p);
-      if (!isAnimalNearby(uuid)) {
+      if (!isAnimalNearby(l, uuid)) {
         uuid = locateEntity(l);
         cachedEntity.put(p, uuid);
       } else {
         return true;
       }
 
-      return isAnimalNearby(uuid);
+      return isAnimalNearby(l, uuid);
     } catch (Exception e) {
       e.printStackTrace();
       return false;
     }
   }
 
-  private boolean isAnimalNearby(UUID uuid) {
+  private boolean isAnimalNearby(Location l, UUID uuid) {
     return uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
   }
 

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -81,16 +81,22 @@ public class GeneratorMob extends AbstractEnergyProvider {
   @ParametersAreNonnullByDefault
   private boolean isAnimalNearby(Location l) {
     try {
-      UUID uuid = cachedEntity.computeIfAbsent(new BlockPosition(l), this::locateEntity);
-      boolean isAnimalNearby = uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
-      if (!isAnimalNearby) {
-        cachedEntity.remove(new BlockPosition(l));
+      BlockPosition p = new BlockPosition(l);
+      UUID uuid = cachedEntity.get(p);
+      if (!isAnimalNearby(uuid)) {
+        uuid = locateEntity(l);
+        cachedEntity.put(p, uuid);
       }
-      return isAnimalNearby;
+
+      return isAnimalNearby(uuid);
     } catch (Exception e) {
       e.printStackTrace();
       return false;
     }
+  }
+
+  private boolean isAnimalNearby(UUID uuid) {
+    return uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
   }
 
   @ParametersAreNonnullByDefault
@@ -149,7 +155,7 @@ public class GeneratorMob extends AbstractEnergyProvider {
   }
 
   @ParametersAreNonnullByDefault
-  private UUID locateEntity(BlockPosition p) {
-    return p.getWorld().getNearbyEntities(p.toLocation(), mobRange, mobRange, mobRange, this::isValidAnimal).stream().findFirst().map(Entity::getUniqueId).orElse(null);
+  private UUID locateEntity(Location l) {
+    return l.getWorld().getNearbyEntities(l, mobRange, mobRange, mobRange, this::isValidAnimal).stream().findFirst().map(Entity::getUniqueId).orElse(null);
   }
 }

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -68,7 +68,7 @@ public class GeneratorMob extends AbstractEnergyProvider {
       SlimefunItems.CARBONADO, GeneratorMob.GENERATOR_MOB_MEDIUM, SlimefunItems.HEATING_COIL, SlimefunItems.PLUTONIUM,
       SlimefunItems.HEATING_COIL, GeneratorMob.GENERATOR_MOB_MEDIUM, SupremeComponents.INDUCTIVE_MACHINE,
       GeneratorMob.GENERATOR_MOB_MEDIUM};
-  public static final Map<BlockPosition, UUID> cachedEntity = new HashMap<>();
+  protected static final Map<BlockPosition, UUID> cachedEntity = new HashMap<>();
 
   private int energy;
   private int buffer;

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -8,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineTier;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.AbstractEnergyProvider;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
@@ -27,6 +28,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.github.relativobr.supreme.util.ItemUtil.getValueGeneratorsWithLimit;
 
@@ -158,6 +160,8 @@ public class GeneratorMob extends AbstractEnergyProvider {
 
   @ParametersAreNonnullByDefault
   private UUID locateEntity(Location l) {
-    return l.getWorld().getNearbyEntities(l, mobRange, mobRange, mobRange, this::isValidAnimal).stream().findFirst().map(Entity::getUniqueId).orElse(null);
+    final AtomicReference<UUID> uuid = new AtomicReference<>();
+    Slimefun.runSync(() -> uuid.set(l.getWorld().getNearbyEntities(l, mobRange, mobRange, mobRange, this::isValidAnimal).stream().findFirst().map(Entity::getUniqueId).orElse(null)));
+    return uuid.get();
   }
 }

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -82,7 +82,11 @@ public class GeneratorMob extends AbstractEnergyProvider {
   private boolean isAnimalNearby(Location l) {
     try {
       UUID uuid = cachedEntity.computeIfAbsent(new BlockPosition(l), this::locateEntity);
-      return uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
+      boolean isAnimalNearby = uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
+      if (!isAnimalNearby) {
+        cachedEntity.remove(new BlockPosition(l));
+      }
+      return isAnimalNearby;
     } catch (Exception e) {
       e.printStackTrace();
       return false;

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -86,6 +86,8 @@ public class GeneratorMob extends AbstractEnergyProvider {
       if (!isAnimalNearby(uuid)) {
         uuid = locateEntity(l);
         cachedEntity.put(p, uuid);
+      } else {
+        return true;
       }
 
       return isAnimalNearby(uuid);

--- a/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
+++ b/src/main/java/com/github/relativobr/supreme/generators/GeneratorMob.java
@@ -1,8 +1,5 @@
 package com.github.relativobr.supreme.generators;
 
-import static com.github.relativobr.supreme.util.ItemUtil.getValueGeneratorsWithLimit;
-
-import com.github.relativobr.supreme.Supreme;
 import com.github.relativobr.supreme.resource.SupremeComponents;
 import com.github.relativobr.supreme.util.ItemGroups;
 import com.github.relativobr.supreme.util.SupremeItemStack;
@@ -13,11 +10,8 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.MachineTier;
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.AbstractEnergyProvider;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
-import java.util.concurrent.Future;
-import java.util.function.Predicate;
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -27,6 +21,14 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Sheep;
 import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.relativobr.supreme.util.ItemUtil.getValueGeneratorsWithLimit;
 
 public class GeneratorMob extends AbstractEnergyProvider {
 
@@ -66,6 +68,7 @@ public class GeneratorMob extends AbstractEnergyProvider {
       SlimefunItems.CARBONADO, GeneratorMob.GENERATOR_MOB_MEDIUM, SlimefunItems.HEATING_COIL, SlimefunItems.PLUTONIUM,
       SlimefunItems.HEATING_COIL, GeneratorMob.GENERATOR_MOB_MEDIUM, SupremeComponents.INDUCTIVE_MACHINE,
       GeneratorMob.GENERATOR_MOB_MEDIUM};
+  public static final Map<BlockPosition, UUID> cachedEntity = new HashMap<>();
 
   private int energy;
   private int buffer;
@@ -78,10 +81,8 @@ public class GeneratorMob extends AbstractEnergyProvider {
   @ParametersAreNonnullByDefault
   private boolean isAnimalNearby(Location l) {
     try {
-      Predicate<Entity> predicate = this::isValidAnimal;
-      Future<Boolean> task = Bukkit.getScheduler().callSyncMethod(Supreme.inst(),
-          () -> l.getWorld().getNearbyEntities(l, mobRange, mobRange, mobRange, predicate).isEmpty());
-      return !task.get();
+      UUID uuid = cachedEntity.computeIfAbsent(new BlockPosition(l), this::locateEntity);
+      return uuid != null && Bukkit.getEntity(uuid) != null && l.distanceSquared(Bukkit.getEntity(uuid).getLocation()) <= Math.pow(mobRange, 2);
     } catch (Exception e) {
       e.printStackTrace();
       return false;
@@ -120,15 +121,12 @@ public class GeneratorMob extends AbstractEnergyProvider {
   }
 
   @Override
-  protected void registerDefaultFuelTypes() {
-  }
+  protected void registerDefaultFuelTypes() {}
 
   @Override
+  @ParametersAreNonnullByDefault
   public int getGeneratedOutput(Location l, Config config) {
-    if (l != null) {
-      return isAnimalNearby(l) ? getEnergyProduction() : 0;
-    }
-    return 0;
+    return isAnimalNearby(l) ? getEnergyProduction() : 0;
   }
 
   @Override
@@ -144,5 +142,10 @@ public class GeneratorMob extends AbstractEnergyProvider {
   @Override
   public int[] getOutputSlots() {
     return new int[0];
+  }
+
+  @ParametersAreNonnullByDefault
+  private UUID locateEntity(BlockPosition p) {
+    return p.getWorld().getNearbyEntities(p.toLocation(), mobRange, mobRange, mobRange, this::isValidAnimal).stream().findFirst().map(Entity::getUniqueId).orElse(null);
   }
 }


### PR DESCRIPTION
What it changes:
- Adds cachedEntity, a map of block position to uuid.
- Each tick of the generator it will check if the cached uuid of an entity is of a mob in range, if it is, then its a quick check, if its not, then it will search for a new entity and cache the result then return if that uuid is within range(aka if the uuid is not null and the entity holding that uuid is within range).

Related Issues:
Resolves #29 

Results of testing, before my changes:
![image](https://user-images.githubusercontent.com/65748158/229628650-297c54f2-ed91-4a64-9c11-6bced6451748.png)

After my changes:
![image](https://user-images.githubusercontent.com/65748158/229628694-ca520048-a62e-4a1b-b9a6-e5934db576bf.png)
