### PR TITLE
Misc Supreme Optimizations 

### DIFF
--- a/src/main/java/com/github/relativobr/supreme/machine/tech/TechGenerator.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/tech/TechGenerator.java
@@ -1,15 +1,14 @@
 package com.github.relativobr.supreme.machine.tech;
 
-import com.github.relativobr.supreme.machine.tech.MobTechGeneric.MobTechType;
-import com.github.relativobr.supreme.generic.machine.SimpleItemContainerMachine;
-import com.github.relativobr.supreme.generic.recipe.InventoryRecipe;
-import com.github.relativobr.supreme.generic.recipe.AbstractItemRecipe;
 import com.github.relativobr.supreme.Supreme;
+import com.github.relativobr.supreme.generic.machine.SimpleItemContainerMachine;
+import com.github.relativobr.supreme.generic.recipe.AbstractItemRecipe;
+import com.github.relativobr.supreme.generic.recipe.InventoryRecipe;
+import com.github.relativobr.supreme.machine.tech.MobTechGeneric.MobTechType;
 import com.github.relativobr.supreme.resource.SupremeComponents;
 import com.github.relativobr.supreme.resource.mobtech.MobTech;
 import com.github.relativobr.supreme.util.ItemGroups;
 import com.github.relativobr.supreme.util.SupremeItemStack;
-import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.UnplaceableBlock;
 import com.github.relativobr.supreme.util.UtilEnergy;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
@@ -19,17 +18,13 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactive;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactivity;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.UnplaceableBlock;
+import io.github.thebusybiscuit.slimefun4.libraries.commons.lang.Validate;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
@@ -37,14 +32,23 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
-import io.github.thebusybiscuit.slimefun4.libraries.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.springframework.scheduling.annotation.Async;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Async
 public class TechGenerator extends SimpleItemContainerMachine implements Radioactive {
@@ -65,8 +69,8 @@ public class TechGenerator extends SimpleItemContainerMachine implements Radioac
       SlimefunItems.HEATING_COIL, SupremeComponents.CARRIAGE_MACHINE};
 
   public static final List<AbstractItemRecipe> receitasParaProduzir = new ArrayList<>();
-  private Map<Block, ItemStack> processing = new HashMap<Block, ItemStack>();
-  private Map<Block, Integer> progressTime = new HashMap<Block, Integer>();
+  private Map<Block, ItemStack> processing = new HashMap<>();
+  private Map<Block, Integer> progressTime = new HashMap<>();
   private int speed = 1;
 
   public TechGenerator(SlimefunItemStack item, ItemStack[] recipe) {
@@ -374,20 +378,28 @@ public class TechGenerator extends SimpleItemContainerMachine implements Radioac
   }
 
   private int checkConsumptionSlot(ItemStack input, int consumption) {
-    if (input != null) {
-      SlimefunItem slimefunItem = SlimefunItem.getByItem(input);
-      if (slimefunItem instanceof MobTech) {
-        final MobTech mobTech = (MobTech) slimefunItem;
-        float perceptual = (mobTech.getMobTechTier() + 1) * input.getAmount() * 0.15625F;
+    if (input != null && !input.getType().isAir() && input.getItemMeta() != null) {
+      NamespacedKey tier = new NamespacedKey(Supreme.inst(), "mob_tech_tier");
+      NamespacedKey type = new NamespacedKey(Supreme.inst(), "mob_tech_type");
+      ItemMeta itemMeta = input.getItemMeta();
+      if (PersistentDataAPI.hasInt(itemMeta, tier) && PersistentDataAPI.hasString(itemMeta, type)) {
+        MobTechType mobTechType = MobTechType.valueOf(PersistentDataAPI.getString(itemMeta, type));
+        int mobTechTier = PersistentDataAPI.getInt(itemMeta, tier);
+        float perceptual = (mobTechTier + 1) * input.getAmount() * 0.15625F;
         int adjustEnergy = Math.round(consumption / 100F * perceptual);
-        if (mobTech.getMobTechType() == MobTechType.ROBOTIC_EFFICIENCY
-            || mobTech.getMobTechType() == MobTechType.MUTATION_INTELLIGENCE) {
+        if (mobTechType == MobTechType.ROBOTIC_EFFICIENCY || mobTechType == MobTechType.MUTATION_INTELLIGENCE) {
           consumption = consumption - adjustEnergy;
         }
-        if (mobTech.getMobTechType() == MobTechType.ROBOTIC_ACCELERATION
-            || mobTech.getMobTechType() == MobTechType.MUTATION_BERSERK) {
+        if (mobTechType == MobTechType.ROBOTIC_ACCELERATION || mobTechType == MobTechType.MUTATION_BERSERK) {
           consumption = consumption + adjustEnergy;
         }
+      } else {
+          SlimefunItem slimefunItem = SlimefunItem.getByItem(input);
+          if (slimefunItem instanceof MobTech) {
+            PersistentDataAPI.setInt(itemMeta, tier, ((MobTech) slimefunItem).getMobTechTier());
+            PersistentDataAPI.setString(itemMeta, type, ((MobTech) slimefunItem).getMobTechType().name());
+            input.setItemMeta(itemMeta);
+          }
       }
     }
     return consumption;

--- a/src/main/java/com/github/relativobr/supreme/machine/tech/TechMutation.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/tech/TechMutation.java
@@ -205,7 +205,7 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
       if (this.getProgressTime(b) <= 0) {
 
         if (UtilMachine.getRandomInt() <= (itemProcessing.getChance() * getUpgradeLuck())) {
-          inv.pushItem(itemProcessing.getOutput().clone(), this.getOutputSlots());
+          inv.pushItem(((ItemStack) itemProcessing.getOutput()).clone(), this.getOutputSlots());
           invalidProgressBar(inv, Material.BLACK_STAINED_GLASS_PANE, " Success! ");
         } else {
           invalidProgressBar(inv, Material.BLACK_STAINED_GLASS_PANE, " Fail! ");

--- a/src/main/java/com/github/relativobr/supreme/machine/tech/TechMutation.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/tech/TechMutation.java
@@ -22,13 +22,6 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
@@ -42,6 +35,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.springframework.scheduling.annotation.Async;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Async
 public class TechMutation extends SimpleItemContainerMachine implements Radioactive {
@@ -122,22 +123,22 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
   protected void constructMenu(BlockMenuPreset preset) {
 
     for (int i : InventoryRecipe.TECH_MUTATION_BORDER) {
-      preset.addItem(i, new CustomItemStack(Material.GRAY_STAINED_GLASS_PANE, " ", new String[0]),
+      preset.addItem(i, new CustomItemStack(Material.GRAY_STAINED_GLASS_PANE, " "),
           ChestMenuUtils.getEmptyClickHandler());
     }
 
     for (int i : InventoryRecipe.TECH_MUTATION_BORDER_IN) {
-      preset.addItem(i, new CustomItemStack(Material.BLUE_STAINED_GLASS_PANE, " ", new String[0]),
+      preset.addItem(i, new CustomItemStack(Material.BLUE_STAINED_GLASS_PANE, " "),
           ChestMenuUtils.getEmptyClickHandler());
     }
 
     for (int i : InventoryRecipe.TECH_MUTATION_BORDER_OUT) {
-      preset.addItem(i, new CustomItemStack(Material.ORANGE_STAINED_GLASS_PANE, " ", new String[0]),
+      preset.addItem(i, new CustomItemStack(Material.ORANGE_STAINED_GLASS_PANE, " "),
           ChestMenuUtils.getEmptyClickHandler());
     }
 
     for (int i : InventoryRecipe.TECH_MUTATION_PROGRESS_BAR_SLOT) {
-      preset.addItem(i, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " ", new String[0]),
+      preset.addItem(i, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "),
           ChestMenuUtils.getEmptyClickHandler());
     }
 
@@ -174,22 +175,23 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
     });
   }
 
+  @Override
   public void tick(Block b) {
 
     BlockMenu inv = BlockStorage.getInventory(b);
 
-    final MobTechMutationGeneric itemNaReceita = validRecipeItem(inv);
-    final MobTechMutationGeneric itemProduzindo = processing.get(b);
-    if (itemProduzindo == null) {
+    final MobTechMutationGeneric itemRecipe = validRecipeItem(inv);
+    final MobTechMutationGeneric itemProcessing = processing.get(b);
+    if (itemProcessing == null) {
 
-      if (itemNaReceita != null) {
+      if (itemRecipe != null) {
 
         inv.consumeItem(getInputSlots()[0], 1);
         inv.consumeItem(getInputSlots()[1], 1);
 
-        invalidProgressBar(inv, itemNaReceita.getOutput().getType(), " ");
+        invalidProgressBar(inv, itemRecipe.getOutput().getType(), " ");
 
-        processing.put(b, itemNaReceita);
+        processing.put(b, itemRecipe);
         progressTime.put(b, (getTimeProcess() * 2));
 
       } else {
@@ -202,8 +204,8 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
 
       if (this.getProgressTime(b) <= 0) {
 
-        if (UtilMachine.getRandomInt() <= (itemProduzindo.getChance() * getUpgradeLuck())) {
-          inv.pushItem(itemProduzindo.getOutput().clone(), this.getOutputSlots());
+        if (UtilMachine.getRandomInt() <= (itemProcessing.getChance() * getUpgradeLuck())) {
+          inv.pushItem(itemProcessing.getOutput().clone(), this.getOutputSlots());
           invalidProgressBar(inv, Material.BLACK_STAINED_GLASS_PANE, " Success! ");
         } else {
           invalidProgressBar(inv, Material.BLACK_STAINED_GLASS_PANE, " Fail! ");
@@ -214,7 +216,7 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
 
       } else {
 
-        this.processTicks(b, inv, itemProduzindo.getOutput());
+        this.processTicks(b, inv, itemProcessing.getOutput());
 
       }
 
@@ -255,8 +257,8 @@ public class TechMutation extends SimpleItemContainerMachine implements Radioact
   private MobTechMutationGeneric validRecipeItem(BlockMenu inv) {
 
     for (MobTechMutationGeneric produce : this.recipes) {
-      ItemStack input1 = produce.getInput1().clone();
-      ItemStack input2 = produce.getInput2().clone();
+      ItemStack input1 = produce.getInput1();
+      ItemStack input2 = produce.getInput2();
       if (SlimefunUtils.isItemSimilar(inv.getItemInSlot(getInputSlots()[0]), input1, false, false)
           && SlimefunUtils.isItemSimilar(inv.getItemInSlot(getInputSlots()[1]), input2, false, false)) {
         return produce;

--- a/src/main/java/com/github/relativobr/supreme/machine/tech/TechRobotic.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/tech/TechRobotic.java
@@ -1,8 +1,8 @@
 package com.github.relativobr.supreme.machine.tech;
 
 import com.github.relativobr.supreme.generic.machine.SimpleItemContainerMachine;
-import com.github.relativobr.supreme.generic.recipe.InventoryRecipe;
 import com.github.relativobr.supreme.generic.recipe.AbstractItemRecipe;
+import com.github.relativobr.supreme.generic.recipe.InventoryRecipe;
 import com.github.relativobr.supreme.resource.SupremeComponents;
 import com.github.relativobr.supreme.resource.magical.SupremeAttribute;
 import com.github.relativobr.supreme.resource.magical.SupremeCetrus;
@@ -22,12 +22,6 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import javax.annotation.Nonnull;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
@@ -41,6 +35,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.springframework.scheduling.annotation.Async;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Async
 public class TechRobotic extends SimpleItemContainerMachine implements Radioactive {
@@ -76,10 +77,10 @@ public class TechRobotic extends SimpleItemContainerMachine implements Radioacti
       SupremeCetrus.CETRUS_LUMIUM, SupremeComponents.CRYSTALLIZER_MACHINE};
 
   public static final List<AbstractItemRecipe> recipes = new ArrayList<>();
-  private Map<Block, ItemStack> processing = new HashMap<Block, ItemStack>();
-  private Map<Block, Integer> progressTime = new HashMap<Block, Integer>();
+  private Map<Block, ItemStack> processing = new HashMap<>();
+  private Map<Block, Integer> progressTime = new HashMap<>();
   private int speed = 1;
-  private int amoundUpgrade = 64;
+  private int amountUpgrade = 64;
 
   public TechRobotic(SlimefunItemStack item, ItemStack[] recipe) {
     super(ItemGroups.MACHINES_CATEGORY, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
@@ -241,10 +242,10 @@ public class TechRobotic extends SimpleItemContainerMachine implements Radioacti
   private ItemStack validRecipeItem(BlockMenu inv) {
 
     for (AbstractItemRecipe produce : this.recipes) {
-      ItemStack itemStack = produce.getFirstItemInput().clone();
-      itemStack.setAmount(getAmoundUpgrade());
+      ItemStack itemStack = produce.getFirstItemInput();
+      itemStack.setAmount(getAmountUpgrade());
       if (SlimefunUtils.isItemSimilar(inv.getItemInSlot(getInputSlots()[0]), itemStack, false, true)) {
-        inv.consumeItem(getInputSlots()[0], getAmoundUpgrade());
+        inv.consumeItem(getInputSlots()[0], getAmountUpgrade());
         return produce.getFirstItemOutput();
       }
 
@@ -260,7 +261,7 @@ public class TechRobotic extends SimpleItemContainerMachine implements Radioacti
         .stream().filter(Objects::nonNull)
         .forEach(recipe -> {
       ItemStack itemStack = recipe.getFirstItemOutput().clone();
-      itemStack.setAmount(getAmoundUpgrade());
+      itemStack.setAmount(getAmountUpgrade());
       displayRecipes.add(itemStack);
       displayRecipes.add(recipe.getFirstItemOutput());
     });
@@ -276,12 +277,12 @@ public class TechRobotic extends SimpleItemContainerMachine implements Radioacti
     return this;
   }
 
-  public int getAmoundUpgrade() {
-    return amoundUpgrade;
+  public int getAmountUpgrade() {
+    return amountUpgrade;
   }
 
-  public TechRobotic setAmoundUpgrade(int amoundUpgrade) {
-    this.amoundUpgrade = amoundUpgrade;
+  public TechRobotic setAmountUpgrade(int amountUpgrade) {
+    this.amountUpgrade = amountUpgrade;
     return this;
   }
 

--- a/src/main/java/com/github/relativobr/supreme/setup/SetupTechMachines.java
+++ b/src/main/java/com/github/relativobr/supreme/setup/SetupTechMachines.java
@@ -55,17 +55,17 @@ public class SetupTechMachines {
           .setMachineIdentifier(TechMutation.TECH_MUTATION_III.getItemId()).setCapacity(500)
           .setEnergyConsumption(500).register(sup);
 
-      new TechRobotic(TechRobotic.TECH_ROBOTIC, TechRobotic.RECIPE_TECH_ROBOTIC).setAmoundUpgrade(
+      new TechRobotic(TechRobotic.TECH_ROBOTIC, TechRobotic.RECIPE_TECH_ROBOTIC).setAmountUpgrade(
               64).setTimeProcess(60).setMachineIdentifier(TechRobotic.TECH_ROBOTIC.getItemId())
           .setCapacity(500).setEnergyConsumption(500).register(sup);
 
       new TechRobotic(TechRobotic.TECH_ROBOTIC_II,
-          TechRobotic.RECIPE_TECH_ROBOTIC_II).setAmoundUpgrade(32).setTimeProcess(60)
+          TechRobotic.RECIPE_TECH_ROBOTIC_II).setAmountUpgrade(32).setTimeProcess(60)
           .setMachineIdentifier(TechRobotic.TECH_ROBOTIC.getItemId()).setCapacity(500)
           .setEnergyConsumption(500).register(sup);
 
       new TechRobotic(TechRobotic.TECH_ROBOTIC_III,
-          TechRobotic.RECIPE_TECH_ROBOTIC_III).setAmoundUpgrade(16).setTimeProcess(60)
+          TechRobotic.RECIPE_TECH_ROBOTIC_III).setAmountUpgrade(16).setTimeProcess(60)
           .setMachineIdentifier(TechRobotic.TECH_ROBOTIC.getItemId()).setCapacity(500)
           .setEnergyConsumption(500).register(sup);
 

--- a/src/main/java/com/github/relativobr/supreme/util/ItemUtil.java
+++ b/src/main/java/com/github/relativobr/supreme/util/ItemUtil.java
@@ -1,26 +1,32 @@
 package com.github.relativobr.supreme.util;
 
-import static com.github.relativobr.supreme.Supreme.getSupremeOptions;
-import static com.github.relativobr.supreme.util.CompatibilySupremeLegacy.getNewIdSupremeLegacy;
-import static com.github.relativobr.supreme.util.CompatibilySupremeLegacy.getOldIdSupremeLegacy;
-
 import com.github.relativobr.supreme.Supreme;
 import com.github.relativobr.supreme.machine.AbstractQuarry;
 import com.github.relativobr.supreme.machine.AbstractQuarryOutputItem;
 import com.github.relativobr.supreme.machine.tech.MobTechGeneric;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactivity;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static com.github.relativobr.supreme.Supreme.getSupremeOptions;
+import static com.github.relativobr.supreme.util.CompatibilySupremeLegacy.getNewIdSupremeLegacy;
+import static com.github.relativobr.supreme.util.CompatibilySupremeLegacy.getOldIdSupremeLegacy;
 
 public class ItemUtil {
 
@@ -268,13 +274,17 @@ public class ItemUtil {
         }
     }
 
-    public static SlimefunItemStack buildItemFromMobTechDTO(MobTechGeneric mobTechGeneric,
-                                                            Integer tier) {
-        return new SlimefunItemStack(buildIdTier(mobTechGeneric.getId(), tier),
+    public static SlimefunItemStack buildItemFromMobTechDTO(MobTechGeneric mobTechGeneric, Integer tier) {
+        SlimefunItemStack itemStack = new SlimefunItemStack(buildIdTier(mobTechGeneric.getId(), tier),
                 mobTechGeneric.getTexture(),
                 buildNameTier(mobTechGeneric.getName(), tier), "",
                 buildLoreRadioactivityType(mobTechGeneric.getMobTechType()),
                 buildLoreType(mobTechGeneric.getMobTechType(), tier),
                 buildLoreTypeAmount(mobTechGeneric.getMobTechType(), tier), "", "&3Supreme Component");
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        PersistentDataAPI.setInt(itemMeta, new NamespacedKey(Supreme.inst(), "mob_tech_tier"), tier);
+        PersistentDataAPI.setString(itemMeta, new NamespacedKey(Supreme.inst(), "mob_tech_type"), mobTechGeneric.getMobTechType().name());
+        itemStack.setItemMeta(itemMeta);
+        return itemStack;
     }
 }


### PR DESCRIPTION
This PR:
- Fixes some Misspellings
- Optimizes TechMutation & TechRobotic by removing unnecessary .clone() calls from SlimefunItemStack
- Optimizes TechGenerator by adding the tier & type of MobTech to its NBT data, to remove the laggy SlimefunItem#fromItem call. If the item does not have the relevant NBT it will fallback to the SlimefunItem#fromItem and if it is a MobTech it will add the relevant NBT data.