### PR TITLE
Correct the value Joules Capacitor Store for Thorium, Supreme

### DIFF
--- a/src/main/java/com/github/relativobr/supreme/util/ItemUtil.java
+++ b/src/main/java/com/github/relativobr/supreme/util/ItemUtil.java
@@ -32,7 +32,7 @@ public class ItemUtil {
 
 
     public static int getValueGeneratorsWithLimit(int value) {
-        return Math.min((getSupremeOptions().isLimitProductionGenerators() ? (value / 5) : value), 16000000);
+        return Math.min((getSupremeOptions().isLimitProductionGenerators() ? (value / 5) : value), 1600000000);
     }
 
     public static SupremeQuarryOutput getOutputQuarry(@Nonnull SlimefunItemStack item) {


### PR DESCRIPTION
Because they using Math.min so 16m < 100m && 1.6b so Thorium and Supreme capacitor only store 16m

Before:
![image](https://github.com/Slimefun-Addon-Community/Supreme/assets/52485153/b89cd935-0c91-4610-bed2-2c19081ad8a6)

After:
![image](https://github.com/Slimefun-Addon-Community/Supreme/assets/52485153/944d9291-d99f-4110-904d-b2ebbfbc41b6)
