### PR TITLE
Fix error when using the latest version of bukkit/paper caused by obsolete methods...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.1</modelVersion>
     <groupId>com.github.relativobr</groupId>
     <artifactId>Supreme</artifactId>
     <version>MODIFIED</version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>1aeb0e8</version>
+            <version>cde3a3f</version>
             <scope>provided</scope>
         </dependency>
 
@@ -69,9 +69,9 @@
 
       <!-- translation plugin -->
         <dependency>
-            <groupId>net.guizhanss</groupId>
+            <groupId>com.github.ybw0014</groupId>
             <artifactId>GuizhanLib</artifactId>
-            <version>0.9.0</version>
+            <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/com/github/relativobr/supreme/SupremeLocalization.java
+++ b/src/main/java/com/github/relativobr/supreme/SupremeLocalization.java
@@ -4,8 +4,9 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+
 import net.guizhanss.guizhanlib.localization.Localization;
-import net.guizhanss.guizhanlib.utils.ChatUtil;
+import net.guizhanss.guizhanlib.minecraft.utils.ChatUtil;
 import net.guizhanss.guizhanlib.utils.StringUtil;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -57,7 +58,6 @@ public class SupremeLocalization extends Localization {
   public void sendMessage(Player p, String messageKey, Object... args) {
     Validate.notNull(p, "Player cannot be null");
     Validate.notNull(messageKey, "Message key cannot be null");
-
     ChatUtil.send(p, MessageFormat.format(getString("messages." + messageKey), args));
   }
 

--- a/src/main/java/com/github/relativobr/supreme/util/EnchantsAndEffectsUtil.java
+++ b/src/main/java/com/github/relativobr/supreme/util/EnchantsAndEffectsUtil.java
@@ -4,6 +4,7 @@ import com.github.relativobr.supreme.Supreme;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -120,7 +121,8 @@ public class EnchantsAndEffectsUtil {
 
         Map<Enchantment, Integer> enchants = new HashMap<>();
         for (String path : section.getKeys(false)) {
-            Enchantment e = Enchantment.getByKey(NamespacedKey.minecraft(path));
+            Enchantment e = Registry.ENCHANTMENT.get(NamespacedKey.minecraft(path));
+
             if (e != null) {
                 int level = section.getInt(path);
                 if (level > 0 && level <= 100) {
@@ -262,7 +264,7 @@ public class EnchantsAndEffectsUtil {
         if (section != null) {
             List<PotionEffect> potionEffects = new ArrayList<>();
             for (String key : section.getKeys(true)) {
-                PotionEffectType potionEffectType = PotionEffectType.getByName(key);
+                PotionEffectType potionEffectType = Registry.EFFECT.get(NamespacedKey.minecraft(key));
                 // check enable
                 if (section.getBoolean(key) && potionEffectType != null) {
                     potionEffects.add(new PotionEffect(potionEffectType, 600, amplifier, false, false, false));
@@ -279,10 +281,10 @@ public class EnchantsAndEffectsUtil {
         List<String> names = new ArrayList<>();
         if (section != null) {
             for (String key : section.getKeys(true)) {
-                PotionEffectType potionEffectType = PotionEffectType.getByName(key);
+                PotionEffectType potionEffectType = Registry.EFFECT.get(NamespacedKey.minecraft(key));
                 // check enable
                 if (section.getBoolean(key) && potionEffectType != null) {
-                    String name = potionEffectType.getName();
+                    String name = potionEffectType.getKey().toString();
                     name = name.replace("_", " ");
                     name = name.substring(0, 1).toUpperCase().concat(name.substring(1).toLowerCase());
                     names.add(name);


### PR DESCRIPTION
# Details
This PR fixes an error that occurs when using the latest versions of the bukkit API, and updates some dependencies.

# Versions
- Minecraft: 1.20.4
- Paper: 1.20.4-484
- OpenJDK: 17.0.10 2024-01-16

# Paper
I used the paper as a reference to correct it, and after the correction the plugin started to work normally, without any warnings or errors.

# Screenshots
![2024-04-18-100034_1920x1080_scrot](https://github.com/Slimefun-Addon-Community/Supreme/assets/158287163/906cd865-5557-42fc-888a-3308a322bf67)
