### PR TITLE
feat: Improve Compatibility with Paper 1.21.0 by Streamlining ItemStack Usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <version>MODIFIED</version>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <author>RelativoBR</author>
     </properties>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>1aeb0e8</version>
+            <version>RC-37</version>
             <scope>provided</scope>
         </dependency>
 
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.3.19</version>
+            <version>6.1.10</version>
         </dependency>
 
       <!-- translation plugin -->
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0</version>
                 <configuration>
                     <minimizeJar>true</minimizeJar>
                     <filters>

--- a/src/main/java/com/github/relativobr/supreme/Supreme.java
+++ b/src/main/java/com/github/relativobr/supreme/Supreme.java
@@ -137,7 +137,7 @@ public class Supreme extends JavaPlugin implements SlimefunAddon {
     instance = this;
 
     Supreme.inst().log(Level.INFO, "########################################");
-    Supreme.inst().log(Level.INFO, "      Supreme 2.0  - By RelativoBR      ");
+    Supreme.inst().log(Level.INFO, "      Supreme - By RelativoBR      ");
     Supreme.inst().log(Level.INFO, "########################################");
 
     Config cfg = new Config(this);
@@ -147,13 +147,10 @@ public class Supreme extends JavaPlugin implements SlimefunAddon {
       return;
     }
 
-    if (getSupremeOptions().isAutoUpdate() && cfg.getBoolean("options.auto-update")
-        && getDescription().getVersion()
-        .startsWith("DEV - ")) {
-      Supreme.inst().log(Level.INFO, "Auto Update: enable");
+		var autoUpdate = getSupremeOptions().isAutoUpdate() && getDescription().getVersion().startsWith("Dev");
+		Supreme.inst().log(Level.INFO, "auto-update: " + autoUpdate);
+    if (autoUpdate) {
       new BlobBuildUpdater(this, getFile(), "Supreme", "Dev").start();
-    } else {
-      Supreme.inst().log(Level.INFO, "Auto Update: disable");
     }
 
     // localization

--- a/src/main/java/com/github/relativobr/supreme/machine/ElectricCrafter.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/ElectricCrafter.java
@@ -48,9 +48,9 @@ public class ElectricCrafter extends FlexItemContainerMachine {
       SupremeCetrus.CETRUS_LUMIUM, SupremeComponents.CRYSTALLIZER_MACHINE};
 
   public static final AbstractItemRecipe RECIPE_BATTERY = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.ZINC_INGOT), new ItemStack(SlimefunItems.SULFATE),
-          new ItemStack(SlimefunItems.COPPER_INGOT), new ItemStack(SlimefunItems.ZINC_INGOT),
-          new ItemStack(SlimefunItems.SULFATE), new ItemStack(SlimefunItems.COPPER_INGOT),
+      new ItemStack[]{SlimefunItems.ZINC_INGOT, SlimefunItems.SULFATE,
+          SlimefunItems.COPPER_INGOT, SlimefunItems.ZINC_INGOT,
+          SlimefunItems.SULFATE, SlimefunItems.COPPER_INGOT,
           new ItemStack(Material.REDSTONE), null, null}, new SlimefunItemStack(SlimefunItems.BATTERY, 1));
   public static final AbstractItemRecipe RECIPE_BLAZE_POWDER = new AbstractItemRecipe(
       new ItemStack[]{new ItemStack(Material.BLAZE_ROD), null, null, null, null, null, null, null, null},

--- a/src/main/java/com/github/relativobr/supreme/machine/Foundry.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/Foundry.java
@@ -1,13 +1,21 @@
 package com.github.relativobr.supreme.machine;
 
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_DIAMOND;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_EMERALD;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_GOLD;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_IRON;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_LAPIS;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_NETHERITE;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_QUARTZ;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreAlloy.RESOURCE_CORE_REDSTONE;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreBlock.RESOURCE_CORE_GRAVEL;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreColor.RESOURCE_CORE_BLACK;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreDeath.RESOURCE_CORE_STRING;
+import static com.github.relativobr.supreme.resource.core.SupremeCoreLife.RESOURCE_CORE_APPLE;
+
 import com.github.relativobr.supreme.generic.machine.MediumContainerMachine;
 import com.github.relativobr.supreme.generic.recipe.AbstractItemRecipe;
 import com.github.relativobr.supreme.resource.SupremeComponents;
-import com.github.relativobr.supreme.resource.core.SupremeCoreAlloy;
-import com.github.relativobr.supreme.resource.core.SupremeCoreBlock;
-import com.github.relativobr.supreme.resource.core.SupremeCoreColor;
-import com.github.relativobr.supreme.resource.core.SupremeCoreDeath;
-import com.github.relativobr.supreme.resource.core.SupremeCoreLife;
 import com.github.relativobr.supreme.resource.magical.SupremeAttribute;
 import com.github.relativobr.supreme.resource.magical.SupremeCetrus;
 import com.github.relativobr.supreme.resource.magical.SupremeCore;
@@ -57,70 +65,48 @@ public class Foundry extends MediumContainerMachine {
       SupremeAttribute.getFortune(), SupremeComponents.THORNERITE, SupremeComponents.SUPREME,
       Foundry.FOUNDRY_MACHINE_II, SupremeComponents.SUPREME, SupremeComponents.CRYSTALLIZER_MACHINE,
       SupremeCetrus.CETRUS_LUMIUM, SupremeComponents.CRYSTALLIZER_MACHINE};
-
+	
   public static final AbstractItemRecipe RECIPE_BLISTERING_INGOT_3 = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_EMERALD)},
+			new ItemStack[]{RESOURCE_CORE_EMERALD, RESOURCE_CORE_EMERALD, RESOURCE_CORE_EMERALD,
+					RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD,
+					RESOURCE_CORE_EMERALD, RESOURCE_CORE_EMERALD, RESOURCE_CORE_EMERALD},
       new SlimefunItemStack(SlimefunItems.BLISTERING_INGOT_3, 64));
-  public static final AbstractItemRecipe RECIPE_REDSTONE_ALLOY = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_REDSTONE)},
-      new SlimefunItemStack(SlimefunItems.REDSTONE_ALLOY, 64));
-  public static final AbstractItemRecipe RECIPE_HARDENED_METAL_INGOT = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_LAPIS)},
-      new SlimefunItemStack(SlimefunItems.HARDENED_METAL_INGOT, 64));
-  public static final AbstractItemRecipe RECIPE_REINFORCED_ALLOY_INGOT = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_DIAMOND),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_NETHERITE)},
-      new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 64));
-  public static final AbstractItemRecipe RECIPE_ENCHANTED_GOLDEN_APPLE = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD),
-          new ItemStack(SupremeCoreLife.RESOURCE_CORE_APPLE), new ItemStack(SupremeCoreLife.RESOURCE_CORE_APPLE),
-          new ItemStack(SupremeCoreLife.RESOURCE_CORE_APPLE), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_GOLD)},
-      new ItemStack(Material.ENCHANTED_GOLDEN_APPLE, 64));
-  public static final AbstractItemRecipe RECIPE_SOLAR_PANEL = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ),
-          new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING), new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING),
-          new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_QUARTZ)},
-      new SlimefunItemStack(SlimefunItems.SOLAR_PANEL, 64));
-  public static final AbstractItemRecipe RECIPE_OIL_BUCKET = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK),
-          new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK), new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_IRON), new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_IRON),
-          new ItemStack(SupremeCoreAlloy.RESOURCE_CORE_IRON), new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK),
-          new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK), new ItemStack(SupremeCoreColor.RESOURCE_CORE_BLACK)},
-      new SlimefunItemStack(SlimefunItems.OIL_BUCKET, 64));
-  public static final AbstractItemRecipe RECIPE_PLASTIC_SHEET = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING),
-          new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING), new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING),
-          new ItemStack(SupremeCoreBlock.RESOURCE_CORE_GRAVEL), new ItemStack(SupremeCoreBlock.RESOURCE_CORE_GRAVEL),
-          new ItemStack(SupremeCoreBlock.RESOURCE_CORE_GRAVEL), new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING),
-          new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING), new ItemStack(SupremeCoreDeath.RESOURCE_CORE_STRING)},
-      new SlimefunItemStack(SlimefunItems.PLASTIC_SHEET, 64));
-
+	public static final AbstractItemRecipe RECIPE_REDSTONE_ALLOY = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_REDSTONE, RESOURCE_CORE_REDSTONE, RESOURCE_CORE_REDSTONE,
+					RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND,
+					RESOURCE_CORE_REDSTONE, RESOURCE_CORE_REDSTONE, RESOURCE_CORE_REDSTONE},
+			new SlimefunItemStack(SlimefunItems.REDSTONE_ALLOY, 64));
+	public static final AbstractItemRecipe RECIPE_HARDENED_METAL_INGOT = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_LAPIS, RESOURCE_CORE_LAPIS, RESOURCE_CORE_LAPIS,
+					RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND,
+					RESOURCE_CORE_LAPIS, RESOURCE_CORE_LAPIS, RESOURCE_CORE_LAPIS},
+			new SlimefunItemStack(SlimefunItems.HARDENED_METAL_INGOT, 64));
+	public static final AbstractItemRecipe RECIPE_REINFORCED_ALLOY_INGOT = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_NETHERITE, RESOURCE_CORE_NETHERITE, RESOURCE_CORE_NETHERITE,
+					RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND, RESOURCE_CORE_DIAMOND,
+					RESOURCE_CORE_NETHERITE, RESOURCE_CORE_NETHERITE, RESOURCE_CORE_NETHERITE},
+			new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 64));
+	public static final AbstractItemRecipe RECIPE_ENCHANTED_GOLDEN_APPLE = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD,
+					RESOURCE_CORE_APPLE, RESOURCE_CORE_APPLE, RESOURCE_CORE_APPLE,
+					RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD, RESOURCE_CORE_GOLD},
+			new ItemStack(Material.ENCHANTED_GOLDEN_APPLE, 64));
+	public static final AbstractItemRecipe RECIPE_SOLAR_PANEL = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_QUARTZ, RESOURCE_CORE_QUARTZ, RESOURCE_CORE_QUARTZ,
+					RESOURCE_CORE_STRING, RESOURCE_CORE_STRING, RESOURCE_CORE_STRING,
+					RESOURCE_CORE_QUARTZ, RESOURCE_CORE_QUARTZ, RESOURCE_CORE_QUARTZ},
+			new SlimefunItemStack(SlimefunItems.SOLAR_PANEL, 64));
+	public static final AbstractItemRecipe RECIPE_OIL_BUCKET = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_BLACK, RESOURCE_CORE_BLACK, RESOURCE_CORE_BLACK,
+					RESOURCE_CORE_IRON, RESOURCE_CORE_IRON, RESOURCE_CORE_IRON,
+					RESOURCE_CORE_BLACK, RESOURCE_CORE_BLACK, RESOURCE_CORE_BLACK},
+			new SlimefunItemStack(SlimefunItems.OIL_BUCKET, 64));
+	public static final AbstractItemRecipe RECIPE_PLASTIC_SHEET = new AbstractItemRecipe(
+			new ItemStack[]{RESOURCE_CORE_STRING, RESOURCE_CORE_STRING, RESOURCE_CORE_STRING,
+					RESOURCE_CORE_GRAVEL, RESOURCE_CORE_GRAVEL, RESOURCE_CORE_GRAVEL,
+					RESOURCE_CORE_STRING, RESOURCE_CORE_STRING, RESOURCE_CORE_STRING},
+			new SlimefunItemStack(SlimefunItems.PLASTIC_SHEET, 64));
+	
   public Foundry(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
     super(category, item, recipeType, recipe);
   }

--- a/src/main/java/com/github/relativobr/supreme/machine/MagicAltar.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/MagicAltar.java
@@ -51,165 +51,105 @@ public class MagicAltar extends MediumContainerMachine {
       SupremeCetrus.CETRUS_LUMIUM, SupremeComponents.CRYSTALLIZER_MACHINE};
 	
 	public static final AbstractItemRecipe RECIPE_RUNE_AIR = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER),
+			new ItemStack[]{new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER),
 					new ItemStack(Material.GHAST_TEAR), SlimefunItems.BLANK_RUNE, new ItemStack(Material.GHAST_TEAR),
-					new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER)
-			},
-			new SlimefunItemStack(SlimefunItems.AIR_RUNE, 4)
-	);
+					new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER)},
+			new SlimefunItemStack(SlimefunItems.AIR_RUNE, 4));
 	public static final AbstractItemRecipe RECIPE_RUNE_EARTH = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.DIRT), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
+			new ItemStack[]{new ItemStack(Material.DIRT), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
 					new ItemStack(Material.OBSIDIAN), SlimefunItems.BLANK_RUNE, new ItemStack(Material.OBSIDIAN),
-					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.DIRT)
-			},
-			new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 4)
-	);
+					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.DIRT)},
+			new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 4));
 	public static final AbstractItemRecipe RECIPE_RUNE_FIRE = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE),
+			new ItemStack[]{new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE),
 					new ItemStack(Material.BLAZE_POWDER), SlimefunItems.EARTH_RUNE, new ItemStack(Material.FLINT_AND_STEEL),
-					new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE)
-			},
-			new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 4)
-	);
+					new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE)},
+			new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 4));
 	public static final AbstractItemRecipe RECIPE_RUNE_WATER = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.SALMON), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.WATER_BUCKET),
+			new ItemStack[]{new ItemStack(Material.SALMON), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.WATER_BUCKET),
 					new ItemStack(Material.SAND), SlimefunItems.BLANK_RUNE, new ItemStack(Material.SAND),
-					new ItemStack(Material.WATER_BUCKET), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.COD)
-			},
-			new SlimefunItemStack(SlimefunItems.WATER_RUNE, 4)
-	);
+					new ItemStack(Material.WATER_BUCKET), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.COD)},
+			new SlimefunItemStack(SlimefunItems.WATER_RUNE, 4));
 	public static final AbstractItemRecipe RECIPE_RUNE_ENDER = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL),
+			new ItemStack[]{new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL),
 					new ItemStack(Material.ENDER_EYE), SlimefunItems.BLANK_RUNE, new ItemStack(Material.ENDER_EYE),
-					new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL)
-			},
-			new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 6)
-	);
+					new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL)},
+			new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 6));
 	public static final AbstractItemRecipe RECIPE_RUNE_LIGHTNING = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT),
+			new ItemStack[]{new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT),
 					SlimefunItems.AIR_RUNE, new ItemStack(Material.PHANTOM_MEMBRANE), SlimefunItems.WATER_RUNE,
-					new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT)
-			},
-			new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 4)
-	);
+					new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT)},
+			new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 4));
 	public static final AbstractItemRecipe RECIPE_RUNE_RAINBOW = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.RED_DYE), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.CYAN_DYE),
+			new ItemStack[]{new ItemStack(Material.RED_DYE), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.CYAN_DYE),
 					new ItemStack(Material.WHITE_WOOL), SlimefunItems.ENDER_RUNE, new ItemStack(Material.WHITE_WOOL),
-					new ItemStack(Material.YELLOW_DYE), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.MAGENTA_DYE)
-			},
-			new SlimefunItemStack(SlimefunItems.RAINBOW_RUNE, 1)
-	);
+					new ItemStack(Material.YELLOW_DYE), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.MAGENTA_DYE)},
+			new SlimefunItemStack(SlimefunItems.RAINBOW_RUNE, 1));
 	public static final AbstractItemRecipe RECIPE_RUNE_SOULBOUND = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3,
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3,
 					SlimefunItems.ENDER_LUMP_3, SlimefunItems.ENDER_RUNE, SlimefunItems.ENDER_LUMP_3,
-					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3
-			},
-			new SlimefunItemStack(SlimefunItems.SOULBOUND_RUNE, 1)
-	);
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3},
+			new SlimefunItemStack(SlimefunItems.SOULBOUND_RUNE, 1));
 	public static final AbstractItemRecipe RECIPE_RUNE_ENCHANTMENT = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3,
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3,
 					SlimefunItems.MAGICAL_GLASS, SlimefunItems.LIGHTNING_RUNE, SlimefunItems.MAGICAL_GLASS,
-					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3
-			},
-			new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 1)
-	);
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3},
+			new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 1));
 	public static final AbstractItemRecipe RECIPE_RUNE_VILLAGERS = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, new ItemStack(Material.CRYING_OBSIDIAN),
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, new ItemStack(Material.CRYING_OBSIDIAN),
 					SlimefunItems.STRANGE_NETHER_GOO, SlimefunItems.FIRE_RUNE, SlimefunItems.STRANGE_NETHER_GOO,
-					new ItemStack(Material.CRYING_OBSIDIAN), SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3
-			},
-			new SlimefunItemStack(SlimefunItems.VILLAGER_RUNE, 3)
-	);
+					new ItemStack(Material.CRYING_OBSIDIAN), SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3},
+			new SlimefunItemStack(SlimefunItems.VILLAGER_RUNE, 3));
 	public static final AbstractItemRecipe RECIPE_BLANK_RUNE = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
+			new ItemStack[]{new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
 					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.OBSIDIAN), SlimefunItems.MAGIC_LUMP_1,
-					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE)
-			},
-			new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 1)
-	);
+					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE)},
+			new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 1));
 	public static final AbstractItemRecipe RECIPE_ESSENCE_OF_AFTERLIFE = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
+			new ItemStack[]{SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
 					SlimefunItems.EARTH_RUNE, SlimefunItems.NECROTIC_SKULL, SlimefunItems.FIRE_RUNE,
-					SlimefunItems.ENDER_LUMP_3, SlimefunItems.WATER_RUNE, SlimefunItems.ENDER_LUMP_3
-			},
-			new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 1)
-	);
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.WATER_RUNE, SlimefunItems.ENDER_LUMP_3},
+			new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 1));
 	public static final AbstractItemRecipe RECIPE_LAVA_CRYSTAL = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1,
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1,
 					new ItemStack(Material.BLAZE_POWDER), SlimefunItems.FIRE_RUNE, new ItemStack(Material.BLAZE_POWDER),
-					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1
-			},
-			new SlimefunItemStack(SlimefunItems.LAVA_CRYSTAL, 1)
-	);
+					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1},
+			new SlimefunItemStack(SlimefunItems.LAVA_CRYSTAL, 1));
 	public static final AbstractItemRecipe RECIPE_MAGICAL_GLASS = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_DUST, SlimefunItems.MAGIC_LUMP_2,
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_DUST, SlimefunItems.MAGIC_LUMP_2,
 					new ItemStack(Material.EXPERIENCE_BOTTLE), new ItemStack(Material.GLASS_PANE), new ItemStack(Material.EXPERIENCE_BOTTLE),
-					SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.EXPERIENCE_BOTTLE), SlimefunItems.MAGIC_LUMP_2
-			},
-			new SlimefunItemStack(SlimefunItems.MAGICAL_GLASS, 1)
-	);
+					SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.EXPERIENCE_BOTTLE), SlimefunItems.MAGIC_LUMP_2},
+			new SlimefunItemStack(SlimefunItems.MAGICAL_GLASS, 1));
 	public static final AbstractItemRecipe RECIPE_COMMON_TALISMAN = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2,
+			new ItemStack[]{SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2,
 					null, new ItemStack(Material.EMERALD), null,
-					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2
-			},
-			new SlimefunItemStack(SlimefunItems.COMMON_TALISMAN, 1)
-	);
+					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2},
+			new SlimefunItemStack(SlimefunItems.COMMON_TALISMAN, 1));
 	public static final AbstractItemRecipe RECIPE_MAGICAL_BOOK_COVER = new AbstractItemRecipe(
-			new ItemStack[]{
-					null, SlimefunItems.MAGIC_LUMP_2, null,
+			new ItemStack[]{null, SlimefunItems.MAGIC_LUMP_2, null,
 					SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.BOOK), SlimefunItems.MAGIC_LUMP_2,
-					null, SlimefunItems.MAGIC_LUMP_2, null
-			},
-			new SlimefunItemStack(SlimefunItems.MAGICAL_BOOK_COVER, 1)
-	);
+					null, SlimefunItems.MAGIC_LUMP_2, null},
+			new SlimefunItemStack(SlimefunItems.MAGICAL_BOOK_COVER, 1));
 	public static final AbstractItemRecipe RECIPE_POWER_CRYSTAL = new AbstractItemRecipe(
-			new ItemStack[]{
-					new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE),
+			new ItemStack[]{new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE),
 					SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.SYNTHETIC_DIAMOND, SlimefunItems.SYNTHETIC_SAPPHIRE,
-					new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE)
-			},
-			new SlimefunItemStack(SlimefunItems.POWER_CRYSTAL, 1)
-	);
+					new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE)},
+			new SlimefunItemStack(SlimefunItems.POWER_CRYSTAL, 1));
 	public static final AbstractItemRecipe RECIPE_ELYTRA_SCALE = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
+			new ItemStack[]{SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
 					new ItemStack(Material.PHANTOM_MEMBRANE), new ItemStack(Material.FEATHER), new ItemStack(Material.PHANTOM_MEMBRANE),
-					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3
-			},
-			new SlimefunItemStack(SlimefunItems.ELYTRA_SCALE, 1)
-	);
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3},
+			new SlimefunItemStack(SlimefunItems.ELYTRA_SCALE, 1));
 	public static final AbstractItemRecipe RECIPE_ELITROS = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE,
+			new ItemStack[]{SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE,
 					SlimefunItems.AIR_RUNE, new ItemStack(Material.LEATHER_CHESTPLATE), SlimefunItems.AIR_RUNE,
-					SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE
-			},
-			new ItemStack(Material.ELYTRA, 1)
-	);
+					SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE},
+			new ItemStack(Material.ELYTRA, 1));
 	public static final AbstractItemRecipe RECIPE_INFUSED_ELYTRA = new AbstractItemRecipe(
-			new ItemStack[]{
-					SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE,
+			new ItemStack[]{SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE,
 					SlimefunItems.FLASK_OF_KNOWLEDGE, new ItemStack(Material.ELYTRA), SlimefunItems.FLASK_OF_KNOWLEDGE,
-					SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE
-			},
-			new SlimefunItemStack(SlimefunItems.INFUSED_ELYTRA, 1)
-	);
+					SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE},
+			new SlimefunItemStack(SlimefunItems.INFUSED_ELYTRA, 1));
 	
   public MagicAltar(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
     super(category, item, recipeType, recipe);

--- a/src/main/java/com/github/relativobr/supreme/machine/MagicAltar.java
+++ b/src/main/java/com/github/relativobr/supreme/machine/MagicAltar.java
@@ -49,123 +49,168 @@ public class MagicAltar extends MediumContainerMachine {
       SupremeAttribute.getMagic(), SupremeComponents.THORNERITE, SupremeComponents.SUPREME,
       MagicAltar.MAGIC_ALTAR_MACHINE_II, SupremeComponents.SUPREME, SupremeComponents.CRYSTALLIZER_MACHINE,
       SupremeCetrus.CETRUS_LUMIUM, SupremeComponents.CRYSTALLIZER_MACHINE};
-
-  public static final AbstractItemRecipe RECIPE_RUNE_AIR = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.FEATHER), new ItemStack(SlimefunItems.MAGIC_LUMP_1),
-          new ItemStack(Material.FEATHER), new ItemStack(Material.GHAST_TEAR), new ItemStack(SlimefunItems.BLANK_RUNE),
-          new ItemStack(Material.GHAST_TEAR), new ItemStack(Material.FEATHER),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.FEATHER)},
-      new SlimefunItemStack(SlimefunItems.AIR_RUNE, 4));
-  public static final AbstractItemRecipe RECIPE_RUNE_EARTH = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.DIRT), new ItemStack(SlimefunItems.MAGIC_LUMP_1),
-          new ItemStack(Material.STONE), new ItemStack(Material.OBSIDIAN), new ItemStack(SlimefunItems.BLANK_RUNE),
-          new ItemStack(Material.OBSIDIAN), new ItemStack(Material.STONE), new ItemStack(SlimefunItems.MAGIC_LUMP_1),
-          new ItemStack(Material.DIRT)}, new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 4));
-  public static final AbstractItemRecipe RECIPE_RUNE_FIRE = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.FIRE_CHARGE), new ItemStack(SlimefunItems.MAGIC_LUMP_2),
-          new ItemStack(Material.FIRE_CHARGE), new ItemStack(Material.BLAZE_POWDER),
-          new ItemStack(SlimefunItems.EARTH_RUNE), new ItemStack(Material.FLINT_AND_STEEL),
-          new ItemStack(Material.FIRE_CHARGE), new ItemStack(SlimefunItems.MAGIC_LUMP_2),
-          new ItemStack(Material.FIRE_CHARGE)}, new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 4));
-  public static final AbstractItemRecipe RECIPE_RUNE_WATER = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.SALMON), new ItemStack(SlimefunItems.MAGIC_LUMP_2),
-          new ItemStack(Material.WATER_BUCKET), new ItemStack(Material.SAND), new ItemStack(SlimefunItems.BLANK_RUNE),
-          new ItemStack(Material.SAND), new ItemStack(Material.WATER_BUCKET), new ItemStack(SlimefunItems.MAGIC_LUMP_2),
-          new ItemStack(Material.COD)}, new SlimefunItemStack(SlimefunItems.WATER_RUNE, 4));
-  public static final AbstractItemRecipe RECIPE_RUNE_ENDER = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.ENDER_PEARL), new ItemStack(SlimefunItems.ENDER_LUMP_3),
-          new ItemStack(Material.ENDER_PEARL), new ItemStack(Material.ENDER_EYE),
-          new ItemStack(SlimefunItems.BLANK_RUNE), new ItemStack(Material.ENDER_EYE),
-          new ItemStack(Material.ENDER_PEARL), new ItemStack(SlimefunItems.ENDER_LUMP_3),
-          new ItemStack(Material.ENDER_PEARL)}, new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 6));
-  public static final AbstractItemRecipe RECIPE_RUNE_LIGHTNING = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.IRON_INGOT), new ItemStack(SlimefunItems.MAGIC_LUMP_3),
-          new ItemStack(Material.IRON_INGOT), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(Material.PHANTOM_MEMBRANE), new ItemStack(SlimefunItems.WATER_RUNE),
-          new ItemStack(Material.IRON_INGOT), new ItemStack(SlimefunItems.MAGIC_LUMP_3),
-          new ItemStack(Material.IRON_INGOT)}, new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 4));
-  public static final AbstractItemRecipe RECIPE_RUNE_RAINBOW = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.RED_DYE), new ItemStack(SlimefunItems.MAGIC_LUMP_3),
-          new ItemStack(Material.CYAN_DYE), new ItemStack(Material.WHITE_WOOL), new ItemStack(SlimefunItems.ENDER_RUNE),
-          new ItemStack(Material.WHITE_WOOL), new ItemStack(Material.YELLOW_DYE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(Material.MAGENTA_DYE)},
-      new SlimefunItemStack(SlimefunItems.RAINBOW_RUNE, 1));
-  public static final AbstractItemRecipe RECIPE_RUNE_SOULBOUND = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.ENDER_LUMP_3),
-          new ItemStack(SlimefunItems.ENDER_RUNE), new ItemStack(SlimefunItems.ENDER_LUMP_3),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3)}, new SlimefunItemStack(SlimefunItems.SOULBOUND_RUNE, 1));
-  public static final AbstractItemRecipe RECIPE_RUNE_ENCHANTMENT = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(SlimefunItems.LIGHTNING_RUNE), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3)}, new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 1));
-  public static final AbstractItemRecipe RECIPE_RUNE_VILLAGERS = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_3), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(Material.CRYING_OBSIDIAN), new ItemStack(SlimefunItems.STRANGE_NETHER_GOO),
-          new ItemStack(SlimefunItems.FIRE_RUNE), new ItemStack(SlimefunItems.STRANGE_NETHER_GOO),
-          new ItemStack(Material.CRYING_OBSIDIAN), new ItemStack(SlimefunItems.MAGICAL_GLASS),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_3)}, new SlimefunItemStack(SlimefunItems.VILLAGER_RUNE, 3));
-  public static final AbstractItemRecipe RECIPE_BLANK_RUNE = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.STONE), new ItemStack(SlimefunItems.MAGIC_LUMP_1),
-          new ItemStack(Material.STONE), new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.OBSIDIAN),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.STONE),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.STONE)},
-      new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 1));
-  public static final AbstractItemRecipe RECIPE_ESSENCE_OF_AFTERLIFE = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(SlimefunItems.EARTH_RUNE),
-          new ItemStack(SlimefunItems.NECROTIC_SKULL), new ItemStack(SlimefunItems.FIRE_RUNE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(SlimefunItems.WATER_RUNE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3)}, new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 1));
-  public static final AbstractItemRecipe RECIPE_LAVA_CRYSTAL = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.BLAZE_POWDER),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.BLAZE_POWDER),
-          new ItemStack(SlimefunItems.FIRE_RUNE), new ItemStack(Material.BLAZE_POWDER),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1), new ItemStack(Material.BLAZE_POWDER),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_1)}, new SlimefunItemStack(SlimefunItems.LAVA_CRYSTAL, 1));
-  public static final AbstractItemRecipe RECIPE_MAGICAL_GLASS = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_2), new ItemStack(SlimefunItems.GOLD_DUST),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2), new ItemStack(Material.EXPERIENCE_BOTTLE),
-          new ItemStack(Material.GLASS_PANE), new ItemStack(Material.EXPERIENCE_BOTTLE),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2), new ItemStack(Material.EXPERIENCE_BOTTLE),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2)}, new SlimefunItemStack(SlimefunItems.MAGICAL_GLASS, 1));
-  public static final AbstractItemRecipe RECIPE_COMMON_TALISMAN = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.MAGIC_LUMP_2), new ItemStack(SlimefunItems.GOLD_8K),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2), null, new ItemStack(Material.EMERALD), null,
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2), new ItemStack(SlimefunItems.GOLD_8K),
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2)}, new SlimefunItemStack(SlimefunItems.COMMON_TALISMAN, 1));
-  public static final AbstractItemRecipe RECIPE_MAGICAL_BOOK_COVER = new AbstractItemRecipe(
-      new ItemStack[]{null, new ItemStack(SlimefunItems.MAGIC_LUMP_2), null, new ItemStack(SlimefunItems.MAGIC_LUMP_2),
-          new ItemStack(Material.BOOK), new ItemStack(SlimefunItems.MAGIC_LUMP_2), null,
-          new ItemStack(SlimefunItems.MAGIC_LUMP_2), null}, new SlimefunItemStack(SlimefunItems.MAGICAL_BOOK_COVER, 1));
-  public static final AbstractItemRecipe RECIPE_POWER_CRYSTAL = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(Material.REDSTONE), new ItemStack(SlimefunItems.SYNTHETIC_SAPPHIRE),
-          new ItemStack(Material.REDSTONE), new ItemStack(SlimefunItems.SYNTHETIC_SAPPHIRE),
-          new ItemStack(SlimefunItems.SYNTHETIC_DIAMOND), new ItemStack(SlimefunItems.SYNTHETIC_SAPPHIRE),
-          new ItemStack(Material.REDSTONE), new ItemStack(SlimefunItems.SYNTHETIC_SAPPHIRE),
-          new ItemStack(Material.REDSTONE)}, new SlimefunItemStack(SlimefunItems.POWER_CRYSTAL, 1));
-  public static final AbstractItemRecipe RECIPE_ELYTRA_SCALE = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(Material.PHANTOM_MEMBRANE),
-          new ItemStack(Material.FEATHER), new ItemStack(Material.PHANTOM_MEMBRANE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ENDER_LUMP_3)}, new SlimefunItemStack(SlimefunItems.ELYTRA_SCALE, 1));
-  public static final AbstractItemRecipe RECIPE_ELITROS = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.ELYTRA_SCALE), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ELYTRA_SCALE), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(Material.LEATHER_CHESTPLATE), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ELYTRA_SCALE), new ItemStack(SlimefunItems.AIR_RUNE),
-          new ItemStack(SlimefunItems.ELYTRA_SCALE)}, new ItemStack(Material.ELYTRA, 1));
-  public static final AbstractItemRecipe RECIPE_INFUSED_ELYTRA = new AbstractItemRecipe(
-      new ItemStack[]{new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE), new ItemStack(SlimefunItems.ELYTRA_SCALE),
-          new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE), new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE),
-          new ItemStack(Material.ELYTRA), new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE),
-          new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE), new ItemStack(SlimefunItems.ELYTRA_SCALE),
-          new ItemStack(SlimefunItems.FLASK_OF_KNOWLEDGE)}, new SlimefunItemStack(SlimefunItems.INFUSED_ELYTRA, 1));
-
+	
+	public static final AbstractItemRecipe RECIPE_RUNE_AIR = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER),
+					new ItemStack(Material.GHAST_TEAR), SlimefunItems.BLANK_RUNE, new ItemStack(Material.GHAST_TEAR),
+					new ItemStack(Material.FEATHER), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.FEATHER)
+			},
+			new SlimefunItemStack(SlimefunItems.AIR_RUNE, 4)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_EARTH = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.DIRT), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
+					new ItemStack(Material.OBSIDIAN), SlimefunItems.BLANK_RUNE, new ItemStack(Material.OBSIDIAN),
+					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.DIRT)
+			},
+			new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 4)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_FIRE = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE),
+					new ItemStack(Material.BLAZE_POWDER), SlimefunItems.EARTH_RUNE, new ItemStack(Material.FLINT_AND_STEEL),
+					new ItemStack(Material.FIRE_CHARGE), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.FIRE_CHARGE)
+			},
+			new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 4)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_WATER = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.SALMON), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.WATER_BUCKET),
+					new ItemStack(Material.SAND), SlimefunItems.BLANK_RUNE, new ItemStack(Material.SAND),
+					new ItemStack(Material.WATER_BUCKET), SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.COD)
+			},
+			new SlimefunItemStack(SlimefunItems.WATER_RUNE, 4)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_ENDER = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL),
+					new ItemStack(Material.ENDER_EYE), SlimefunItems.BLANK_RUNE, new ItemStack(Material.ENDER_EYE),
+					new ItemStack(Material.ENDER_PEARL), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.ENDER_PEARL)
+			},
+			new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 6)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_LIGHTNING = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT),
+					SlimefunItems.AIR_RUNE, new ItemStack(Material.PHANTOM_MEMBRANE), SlimefunItems.WATER_RUNE,
+					new ItemStack(Material.IRON_INGOT), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.IRON_INGOT)
+			},
+			new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 4)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_RAINBOW = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.RED_DYE), SlimefunItems.MAGIC_LUMP_3, new ItemStack(Material.CYAN_DYE),
+					new ItemStack(Material.WHITE_WOOL), SlimefunItems.ENDER_RUNE, new ItemStack(Material.WHITE_WOOL),
+					new ItemStack(Material.YELLOW_DYE), SlimefunItems.ENDER_LUMP_3, new ItemStack(Material.MAGENTA_DYE)
+			},
+			new SlimefunItemStack(SlimefunItems.RAINBOW_RUNE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_SOULBOUND = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3,
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.ENDER_RUNE, SlimefunItems.ENDER_LUMP_3,
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_3
+			},
+			new SlimefunItemStack(SlimefunItems.SOULBOUND_RUNE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_ENCHANTMENT = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3,
+					SlimefunItems.MAGICAL_GLASS, SlimefunItems.LIGHTNING_RUNE, SlimefunItems.MAGICAL_GLASS,
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3
+			},
+			new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_RUNE_VILLAGERS = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_3, SlimefunItems.MAGICAL_GLASS, new ItemStack(Material.CRYING_OBSIDIAN),
+					SlimefunItems.STRANGE_NETHER_GOO, SlimefunItems.FIRE_RUNE, SlimefunItems.STRANGE_NETHER_GOO,
+					new ItemStack(Material.CRYING_OBSIDIAN), SlimefunItems.MAGICAL_GLASS, SlimefunItems.MAGIC_LUMP_3
+			},
+			new SlimefunItemStack(SlimefunItems.VILLAGER_RUNE, 3)
+	);
+	public static final AbstractItemRecipe RECIPE_BLANK_RUNE = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE),
+					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.OBSIDIAN), SlimefunItems.MAGIC_LUMP_1,
+					new ItemStack(Material.STONE), SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.STONE)
+			},
+			new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_ESSENCE_OF_AFTERLIFE = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
+					SlimefunItems.EARTH_RUNE, SlimefunItems.NECROTIC_SKULL, SlimefunItems.FIRE_RUNE,
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.WATER_RUNE, SlimefunItems.ENDER_LUMP_3
+			},
+			new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_LAVA_CRYSTAL = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1,
+					new ItemStack(Material.BLAZE_POWDER), SlimefunItems.FIRE_RUNE, new ItemStack(Material.BLAZE_POWDER),
+					SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.BLAZE_POWDER), SlimefunItems.MAGIC_LUMP_1
+			},
+			new SlimefunItemStack(SlimefunItems.LAVA_CRYSTAL, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_MAGICAL_GLASS = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_DUST, SlimefunItems.MAGIC_LUMP_2,
+					new ItemStack(Material.EXPERIENCE_BOTTLE), new ItemStack(Material.GLASS_PANE), new ItemStack(Material.EXPERIENCE_BOTTLE),
+					SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.EXPERIENCE_BOTTLE), SlimefunItems.MAGIC_LUMP_2
+			},
+			new SlimefunItemStack(SlimefunItems.MAGICAL_GLASS, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_COMMON_TALISMAN = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2,
+					null, new ItemStack(Material.EMERALD), null,
+					SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2
+			},
+			new SlimefunItemStack(SlimefunItems.COMMON_TALISMAN, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_MAGICAL_BOOK_COVER = new AbstractItemRecipe(
+			new ItemStack[]{
+					null, SlimefunItems.MAGIC_LUMP_2, null,
+					SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.BOOK), SlimefunItems.MAGIC_LUMP_2,
+					null, SlimefunItems.MAGIC_LUMP_2, null
+			},
+			new SlimefunItemStack(SlimefunItems.MAGICAL_BOOK_COVER, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_POWER_CRYSTAL = new AbstractItemRecipe(
+			new ItemStack[]{
+					new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE),
+					SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.SYNTHETIC_DIAMOND, SlimefunItems.SYNTHETIC_SAPPHIRE,
+					new ItemStack(Material.REDSTONE), SlimefunItems.SYNTHETIC_SAPPHIRE, new ItemStack(Material.REDSTONE)
+			},
+			new SlimefunItemStack(SlimefunItems.POWER_CRYSTAL, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_ELYTRA_SCALE = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3,
+					new ItemStack(Material.PHANTOM_MEMBRANE), new ItemStack(Material.FEATHER), new ItemStack(Material.PHANTOM_MEMBRANE),
+					SlimefunItems.ENDER_LUMP_3, SlimefunItems.AIR_RUNE, SlimefunItems.ENDER_LUMP_3
+			},
+			new SlimefunItemStack(SlimefunItems.ELYTRA_SCALE, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_ELITROS = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE,
+					SlimefunItems.AIR_RUNE, new ItemStack(Material.LEATHER_CHESTPLATE), SlimefunItems.AIR_RUNE,
+					SlimefunItems.ELYTRA_SCALE, SlimefunItems.AIR_RUNE, SlimefunItems.ELYTRA_SCALE
+			},
+			new ItemStack(Material.ELYTRA, 1)
+	);
+	public static final AbstractItemRecipe RECIPE_INFUSED_ELYTRA = new AbstractItemRecipe(
+			new ItemStack[]{
+					SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE,
+					SlimefunItems.FLASK_OF_KNOWLEDGE, new ItemStack(Material.ELYTRA), SlimefunItems.FLASK_OF_KNOWLEDGE,
+					SlimefunItems.FLASK_OF_KNOWLEDGE, SlimefunItems.ELYTRA_SCALE, SlimefunItems.FLASK_OF_KNOWLEDGE
+			},
+			new SlimefunItemStack(SlimefunItems.INFUSED_ELYTRA, 1)
+	);
+	
   public MagicAltar(ItemGroup category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
     super(category, item, recipeType, recipe);
   }

--- a/src/main/java/com/github/relativobr/supreme/resource/SupremeComponents.java
+++ b/src/main/java/com/github/relativobr/supreme/resource/SupremeComponents.java
@@ -238,7 +238,7 @@ public class SupremeComponents {
   public static final SlimefunItemStack CRYSTALLIZER_MACHINE = new SupremeItemStack("SUPREME_CRYSTALLIZER_MACHINE",
       Material.TUBE_CORAL_BLOCK, "&aCrystallizer Machine", "", "&3Supreme Advanced Components");
   public static final ItemStack[] RECIPE_CRYSTALLIZER_MACHINE = {SupremeCoreAlloy.RESOURCE_CORE_DIAMOND,
-      new ItemStack(STAINLESS_MACHINE), SupremeCoreAlloy.RESOURCE_CORE_DIAMOND, SupremeComponents.SYNTHETIC_RUBY,
+      STAINLESS_MACHINE, SupremeCoreAlloy.RESOURCE_CORE_DIAMOND, SupremeComponents.SYNTHETIC_RUBY,
       SupremeComponents.PETRIFIER_MACHINE, SupremeComponents.SYNTHETIC_RUBY, SupremeCoreAlloy.RESOURCE_CORE_EMERALD,
       SupremeComponents.INDUCTOR_MACHINE, SupremeCoreAlloy.RESOURCE_CORE_EMERALD};
 

--- a/src/main/java/com/github/relativobr/supreme/util/ItemTier.java
+++ b/src/main/java/com/github/relativobr/supreme/util/ItemTier.java
@@ -1,44 +1,49 @@
 package com.github.relativobr.supreme.util;
 
-import com.github.relativobr.supreme.resource.SupremeComponents;
-import com.github.relativobr.supreme.resource.magical.SupremeCetrus;
+import static com.github.relativobr.supreme.resource.SupremeComponents.SUPREME;
+import static com.github.relativobr.supreme.resource.SupremeComponents.THORNIUM_BIT_SYNTHETIC;
+import static com.github.relativobr.supreme.resource.SupremeComponents.THORNIUM_CARBONADO;
+import static com.github.relativobr.supreme.resource.SupremeComponents.THORNIUM_DUST_SYNTHETIC;
+import static com.github.relativobr.supreme.resource.SupremeComponents.THORNIUM_ENERGIZED;
+import static com.github.relativobr.supreme.resource.SupremeComponents.THORNIUM_INGOT_SYNTHETIC;
+import static com.github.relativobr.supreme.resource.magical.SupremeCetrus.CETRUS_IGNIS;
+import static com.github.relativobr.supreme.resource.magical.SupremeCetrus.CETRUS_LUMIUM;
+import static com.github.relativobr.supreme.resource.magical.SupremeCetrus.CETRUS_LUX;
+import static com.github.relativobr.supreme.resource.magical.SupremeCetrus.CETRUS_VENTUS;
+
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import org.bukkit.inventory.ItemStack;
 
 public class ItemTier {
 
   public static ItemStack[] getMagicRecipe(SlimefunItemStack preItem) {
-    return new ItemStack[]{SupremeComponents.THORNIUM_BIT_SYNTHETIC, preItem, SupremeComponents.THORNIUM_BIT_SYNTHETIC,
-        SupremeComponents.THORNIUM_BIT_SYNTHETIC, new ItemStack(SupremeCetrus.CETRUS_IGNIS),
-        SupremeComponents.THORNIUM_BIT_SYNTHETIC, SupremeComponents.THORNIUM_BIT_SYNTHETIC, preItem,
-        SupremeComponents.THORNIUM_BIT_SYNTHETIC};
+    return new ItemStack[]{THORNIUM_BIT_SYNTHETIC, preItem, THORNIUM_BIT_SYNTHETIC,
+        THORNIUM_BIT_SYNTHETIC, CETRUS_IGNIS, THORNIUM_BIT_SYNTHETIC,
+				THORNIUM_BIT_SYNTHETIC, preItem, THORNIUM_BIT_SYNTHETIC};
   }
 
   public static ItemStack[] getRareRecipe(SlimefunItemStack preItem) {
-    return new ItemStack[]{SupremeComponents.THORNIUM_DUST_SYNTHETIC, preItem,
-        SupremeComponents.THORNIUM_DUST_SYNTHETIC, SupremeComponents.THORNIUM_DUST_SYNTHETIC,
-        new ItemStack(SupremeCetrus.CETRUS_VENTUS), SupremeComponents.THORNIUM_DUST_SYNTHETIC,
-        SupremeComponents.THORNIUM_DUST_SYNTHETIC, preItem, SupremeComponents.THORNIUM_DUST_SYNTHETIC};
+    return new ItemStack[]{THORNIUM_DUST_SYNTHETIC, preItem, THORNIUM_DUST_SYNTHETIC,
+				THORNIUM_DUST_SYNTHETIC, CETRUS_VENTUS, THORNIUM_DUST_SYNTHETIC,
+        THORNIUM_DUST_SYNTHETIC, preItem, THORNIUM_DUST_SYNTHETIC};
   }
 
   public static ItemStack[] getEpicRecipe(SlimefunItemStack preItem) {
-    return new ItemStack[]{SupremeComponents.THORNIUM_INGOT_SYNTHETIC, preItem,
-        SupremeComponents.THORNIUM_INGOT_SYNTHETIC, SupremeComponents.THORNIUM_INGOT_SYNTHETIC,
-        new ItemStack(SupremeCetrus.CETRUS_LUX), SupremeComponents.THORNIUM_INGOT_SYNTHETIC,
-        SupremeComponents.THORNIUM_INGOT_SYNTHETIC, preItem, SupremeComponents.THORNIUM_INGOT_SYNTHETIC};
+    return new ItemStack[]{THORNIUM_INGOT_SYNTHETIC, preItem, THORNIUM_INGOT_SYNTHETIC,
+				THORNIUM_INGOT_SYNTHETIC, CETRUS_LUX, THORNIUM_INGOT_SYNTHETIC,
+        THORNIUM_INGOT_SYNTHETIC, preItem, THORNIUM_INGOT_SYNTHETIC};
   }
 
   public static ItemStack[] getLegendaryRecipe(SlimefunItemStack preItem) {
-    return new ItemStack[]{SupremeComponents.THORNIUM_CARBONADO, preItem, SupremeComponents.THORNIUM_CARBONADO,
-        SupremeComponents.THORNIUM_CARBONADO, new ItemStack(SupremeCetrus.CETRUS_LUMIUM),
-        SupremeComponents.THORNIUM_CARBONADO, SupremeComponents.THORNIUM_CARBONADO, preItem,
-        SupremeComponents.THORNIUM_CARBONADO};
+    return new ItemStack[]{THORNIUM_CARBONADO, preItem, THORNIUM_CARBONADO,
+        THORNIUM_CARBONADO, CETRUS_LUMIUM, THORNIUM_CARBONADO,
+				THORNIUM_CARBONADO, preItem, THORNIUM_CARBONADO};
   }
 
   public static ItemStack[] getSupremeRecipe(SlimefunItemStack preItem) {
-    return new ItemStack[]{SupremeComponents.THORNIUM_ENERGIZED, preItem, SupremeComponents.THORNIUM_ENERGIZED,
-        SupremeComponents.THORNIUM_ENERGIZED, SupremeComponents.SUPREME, SupremeComponents.THORNIUM_ENERGIZED,
-        SupremeComponents.THORNIUM_ENERGIZED, preItem, SupremeComponents.THORNIUM_ENERGIZED};
+    return new ItemStack[]{THORNIUM_ENERGIZED, preItem, THORNIUM_ENERGIZED,
+        THORNIUM_ENERGIZED, SUPREME, THORNIUM_ENERGIZED,
+        THORNIUM_ENERGIZED, preItem, THORNIUM_ENERGIZED};
   }
 
 }


### PR DESCRIPTION
This PR adjusts the code to ensure compatibility with Paper 1.21.0, following the fixes applied in [PR #63](https://github.com/Slimefun-Addon-Community/Supreme/pull/63). In Paper 1.21.0, ItemStack delegation has changed, and passing an extended instance like SlimefunItemStack to the ItemStack constructor causes exceptions when handling inventories.

This PR removes unnecessary new ItemStack(Supreme*) instances and passes SlimefunItemStack directly to the recipes, preventing issues when running on Paper 1.21.0 servers.