### PR TITLE
fix #68

### DIFF
--- a/src/main/java/com/github/relativobr/supreme/generic/machine/MediumContainerMachine.java
+++ b/src/main/java/com/github/relativobr/supreme/generic/machine/MediumContainerMachine.java
@@ -421,6 +421,8 @@ public class MediumContainerMachine extends AContainer implements NotHopperable,
         progressItem.put(b, i + 1);
         ChestMenuUtils.updateProgressbar(inv, getStatusSlot(), ticksLeft, ticks,
             result[0]);
+      } else {
+        break;
       }
     }
   }


### PR DESCRIPTION
When checking the inputs at the end, the machine doesn't stop when it doesn't find an expected input, and the item progress always gets updated to 9, making it think its complete.