### PR TITLE
fix: update GenericMachine start matching and consumed attempt count

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Make a new issue, pull request, or discord Slimefun-Addon-Community
 - **base-time-mob-collector** - To change the Mob Collector base processing time (default: 15)
 - **base-time-tech-generator** - To change the Tech Generator base processing time (default: 1800)
 - **tech-generator-max-amount** - To change the Tech Generator base result item amount (default: 64)
+- **machine-max-attempt-consumed** - To change the Electric Machines max attempt consumed item retry (default: 30)
 - **mob-tech-enable-bee** - Indication whether to enable the Bee in Mob Tech (default: true)
 - **mob-tech-enable-iron-golem** - Indication whether to enable the Iron Golem in Mob Tech (default: true)
 - **mob-tech-enable-zombie** - Indication whether to enable the Zombie in Mob Tech (default: true)

--- a/src/main/java/com/github/relativobr/supreme/Supreme.java
+++ b/src/main/java/com/github/relativobr/supreme/Supreme.java
@@ -61,6 +61,7 @@ public class Supreme extends JavaPlugin implements SlimefunAddon {
                 .enableArmor(typeSection.getBoolean("enable-armor", true))
                 .enableTech(typeSection.getBoolean("enable-tech", true))
                 .customBc(typeSection.getBoolean("custom-bc", false))
+                .machineMaxAttemptConsumed(typeSection.getInt("machine-max-attempt-consumed", 30))
                 .build();
       }
     }

--- a/src/main/java/com/github/relativobr/supreme/util/SupremeOptions.java
+++ b/src/main/java/com/github/relativobr/supreme/util/SupremeOptions.java
@@ -33,6 +33,7 @@ public class SupremeOptions {
     boolean enableArmor;
     boolean enableTech;
     boolean customBc;
+    int machineMaxAttemptConsumed;
 
     public static SupremeOptions defaultValue() {
         return SupremeOptions.builder()
@@ -58,6 +59,7 @@ public class SupremeOptions {
                 .enableArmor(true)
                 .enableTech(true)
                 .customBc(false)
+                .machineMaxAttemptConsumed(30)
                 .build();
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,7 @@ options:
   enable-armor: true
   enable-tech: true
   custom-bc: false
+  machine-max-attempt-consumed: 30
 # -------------------------------
 # quarry-custom-output
 # -------------------------------


### PR DESCRIPTION
**Issues:**
-  https://github.com/Slimefun-Addon-Community/Supreme/issues/76

The change being implemented aims to resolve this issue, which is related to the inability to distinguish between duplicate items when filling the machine. This adjustment should ensure proper functionality for recipes requiring multiple stacks of different items.
